### PR TITLE
Fix CKAN 2.7 errors

### DIFF
--- a/ckanext/orgdashboards/templates/organization/read_base.html
+++ b/ckanext/orgdashboards/templates/organization/read_base.html
@@ -13,6 +13,6 @@
         <a class="btn" href="{% url_for controller='ckanext.orgdashboards.controllers.dashboard:DashboardsController',
                                                                        action='preview_dashboard',
                                                                        locale=locale,
-                                                                       name=c.group_dict.name%}" target="_blank"><i class="icon-globe"></i> View dashboard</a>
+                                                                       name=c.group_dict.name%}" target="_blank"><i class="icon-globe fa fa-globe"></i> View dashboard</a>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
This PR fixes an error where in one of the helpers, the organization field `display_name` is accessed which was removed in CKAN 2.7. Now it uses the `title` field if the field `display_name` does not exist. This is kept for backwards compatibility for older versions of CKAN.

Also, the icon for "View dashboard" was missing in CKAN 2.7 because Font Awesome was upgraded to a newer version.