### PR TITLE
Remove header menu in dashboard 

### DIFF
--- a/ckanext/orgdashboards/templates/dashboards/index.html
+++ b/ckanext/orgdashboards/templates/dashboards/index.html
@@ -178,6 +178,21 @@
                     </ul>
                 </div>
               {% endif %}
+
+    <nav class="top-navigation pull-right" style="background-color: {{ base_color }}">
+        <div class="">
+            <ul class="list-inline">
+                {% if organization_entity_name == 'country' %}
+                  <li><a href="http://www.usedata.info/about-2/">{{ _('About') }}</a></li>
+                  <li><a href="http://www.usedata.info/help/">{{ _('Help') }}</a></li>
+                  <li><a href="http://www.usedata.info/resources/">{{ _('Resources') }}</a></li>
+                  <li><a href="http://www.usedata.info/contact/">{{ _('Contact') }}</a></li>
+                {% endif %}
+            </ul>
+        </div>
+    </nav>
+
+
             </div>
         </div>
     </header>

--- a/ckanext/orgdashboards/templates/dashboards/index.html
+++ b/ckanext/orgdashboards/templates/dashboards/index.html
@@ -178,26 +178,6 @@
                     </ul>
                 </div>
               {% endif %}
-
-    <nav class="top-navigation pull-right" style="background-color: {{ base_color }}">
-        <div class="">
-            <ul class="list-inline">
-                {% if organization_entity_name == 'country' %}
-                  <li><a href="http://www.usedata.info/about-2/">{{ _('About') }}</a></li>
-                  <li><a href="http://www.usedata.info/help/">{{ _('Help') }}</a></li>
-                  <li><a href="http://www.usedata.info/resources/">{{ _('Resources') }}</a></li>
-                  <li><a href="http://www.usedata.info/contact/">{{ _('Contact') }}</a></li>
-                {% elif organization_entity_name == 'organization' %}
-                  <li><a href="#">{{ _('About') }}</a></li>
-                  <li><a href="#">{{ _('Help') }}</a></li>
-                  <li><a href="#">{{ _('Resources') }}</a></li>
-                  <li><a href="#">{{ _('Contact') }}</a></li>
-                {% endif %}
-            </ul>
-        </div>
-    </nav>
-
-
             </div>
         </div>
     </header>


### PR DESCRIPTION
This PR removes the header menu which is located in the dashboard page except for organization entity name "country", which is used in Montrose portal.