### PR TITLE
Remove footer links in dashboard page

### DIFF
--- a/ckanext/orgdashboards/templates/dashboards/index.html
+++ b/ckanext/orgdashboards/templates/dashboards/index.html
@@ -412,13 +412,6 @@
                           <li><a href="http://www.usedata.info/">{{ _('About USEDATA') }}</a></li>
                           <li><a href="http://www.usedata.info/contact/">{{ _('Contact') }}</a></li>
                           <li><a href="http://www.usedata.info/terms-of-use-2/">{{ _('Terms of use') }}</a></li>
-                        {% elif organization_entity_name == 'organization' %}
-                          {% set logo_prefix = 'Organization' %}
-                          <li><a href="#">{{ _('About') }}</a></li>
-                          <li><a href="#">{{ _('Help') }}</a></li>
-                          <li><a href="#">{{ _('Resources') }}</a></li>
-                          <li><a href="#">{{ _('Contact') }}</a></li>
-                          <li><a href="#">{{ _('Terms of use') }}</a></li>
                         {% endif %}
                     </ul>
                 </div>


### PR DESCRIPTION
This PR removes footer links in dashboard page, since they are unused.